### PR TITLE
Security problem with install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,6 @@ SOURCE_URL =		https://github.com/scaleway/image-app-openvpn
 ## Image tools  (https://github.com/scaleway/image-tools)
 all:	docker-rules.mk
 docker-rules.mk:
-	wget -qO - http://j.mp/scw-builder | bash
+	wget -qO - https://j.mp/scw-builder | bash
 -include docker-rules.mk
 ## Below you can add custom makefile commands and overrides


### PR DESCRIPTION
Make use of TLS to download the bash script. Otherwise an attacker could intercept and make you execute an arbitrary script.